### PR TITLE
operator<< no longer prints endl

### DIFF
--- a/src/bitscan/bbobject.h
+++ b/src/bitscan/bbobject.h
@@ -30,7 +30,7 @@ namespace bitgraph {
 			enum scan_types { NON_DESTRUCTIVE, NON_DESTRUCTIVE_REVERSE, DESTRUCTIVE, DESTRUCTIVE_REVERSE };
 
 			//to stream
-			friend std::ostream& operator<< (std::ostream& o, const BBObject& bb) { bb.print(o); return o; }
+			friend std::ostream& operator<< (std::ostream& o, const BBObject& bb) { bb.print(o, true/*show_pc*/, false/*endl*/); return o; }
 
 			//////////////////
 			// Efficient nested data structures for bitscanning 


### PR DESCRIPTION
The normal behavior of `operator<<` overloads is to not print endl, so by the principle of least surprise it'd be better to follow this convention.  This way you can do things like `std::cout << "a=" << a << ", b=" << b << "\n"` all on one line.