### PR TITLE
fixed ub vector size - it was leading to out-of-bounds access

### DIFF
--- a/src/graph/algorithms/clique/clq_func.h
+++ b/src/graph/algorithms/clique/clq_func.h
@@ -897,7 +897,7 @@ namespace bitgraph {
 
 				int pc = bbsg.size();
 				if (pc == 0) { return 0; }			//early exit - bitset bbsg is empty	
-				ub.assign(pc, 0);
+				ub.assign(g.size(), 0);
 
 				int col = 1, v = bbo::noBit, nBB = bbo::noBit;
 


### PR DESCRIPTION
ISEQ was giving the wrong size to `ub`.  It should be the size of the graph, not the number of selected vertices.  `ub[v] = col` assumes it's indexed the same way as the graph.