### PR TITLE
enabled compiler warnings and fixed some thing thereby found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,14 @@ project(${LIBNAME}
     VERSION  ${LIB_MAJOR_VERS}.${LIB_MINOR_VERS}.${LIB_PATCH_VERS}
 	LANGUAGES CXX C	)
 
+# Enable compiler warnings.
+if (MSVC)
+    # not enabled because this is not a tested target
+    #add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra)
+endif()
+
 #################
 # Introduce variables for export:
 # * CMAKE_INSTALL_LIBDIR		#lib

--- a/src/bitscan/bbalgorithm.h
+++ b/src/bitscan/bbalgorithm.h
@@ -267,7 +267,7 @@ namespace bitgraph {
 					}
 				}
 				catch (std::exception& e) {
-					LOG_ERROR(e.what());
+					LOG_ERROR("%s", e.what());
 					LOG_ERROR("bbCol_t::bbCol_t()");
 					std::exit(EXIT_FAILURE);
 				}
@@ -439,7 +439,7 @@ namespace bitgraph {
 				////////////////////////////
 			}
 			catch (std::exception& e) {
-				LOG_ERROR(e.what());
+				LOG_ERROR("%s", e.what());
 				LOG_ERROR("bbStack_t<BitSetT>::-reset()");
 				std::exit(EXIT_FAILURE);
 			}

--- a/src/bitscan/tables.cpp
+++ b/src/bitscan/tables.cpp
@@ -136,7 +136,7 @@ void Tables::init_masks(){
 			if(j<c) continue; 
 
 			if(j==c) mask_mid[c][j]=mask[c];
-			else mask_mid[c][j]= mask_low[j] & mask_high[c] | mask[c] | mask[j];
+			else mask_mid[c][j]= (mask_low[j] & mask_high[c]) | mask[c] | mask[j];
 		}
 	}
 

--- a/src/graph/algorithms/graph_fast_sort_weighted.h
+++ b/src/graph/algorithms/graph_fast_sort_weighted.h
@@ -60,7 +60,7 @@ namespace bitgraph {
 
 			////////////////////////
 			//construction / destruction
-			GraphFastRootSort_W(GraphW_t& gw) : gw_(gw), GraphFastRootSort<typename GraphW_t::_gt>(gw.graph()) {}
+			GraphFastRootSort_W(GraphW_t& gw) : GraphFastRootSort<typename GraphW_t::_gt>(gw.graph()), gw_(gw) {}
 
 			//move and copy semantics
 			GraphFastRootSort_W(const GraphFastRootSort_W&) = delete;

--- a/src/graph/algorithms/graph_func.h
+++ b/src/graph/algorithms/graph_func.h
@@ -324,7 +324,7 @@ namespace bitgraph {
 			template<class Graph_t>
 			vint& sort_deg(const Graph_t& g, vint& lv, typename  Graph_t::_bbt& bbref, bool min_sort = true) {
 
-				int deg = 0;
+				//int deg = 0;
 
 				//determine the degree of each vertex in lv wrt to ref
 				vint ldeg(g.number_of_vertices(), 0);

--- a/src/graph/algorithms/graph_gen.h
+++ b/src/graph/algorithms/graph_gen.h
@@ -377,7 +377,7 @@ namespace bitgraph{
 		}
 		catch (std::exception& e) {
 			LOG_ERROR("error during isomorphism generation - RandomGen<Graph_t>::create_isomorphism");
-			LOG_ERROR(e.what());
+			LOG_ERROR("%s", e.what());
 			return -1;
 		}
 

--- a/src/graph/algorithms/graph_sort.h
+++ b/src/graph/algorithms/graph_sort.h
@@ -69,19 +69,19 @@ namespace bitgraph {
 			typedef vdeg::iterator					vdeg_it;
 
 			//sorting criteria
-			struct degreeLess /* : public binary_function<deg_t, deg_t, bool>*/ {
+			struct degreeLess {
 				bool operator() (deg_t i, deg_t j) const {
 					return (abs(i.deg) < abs(j.deg));
 				}
 			};
 
-			struct degreeGreater/* : public binary_function<deg_t, deg_t, bool> */ {
+			struct degreeGreater {
 				bool operator() (deg_t i, deg_t j) const {
 					return (i.deg > j.deg);
 				}
 			};
 
-			struct degreeWithTieBreakLess /* : public binary_function<deg_t, deg_t, bool> */ {
+			struct degreeWithTieBreakLess {
 				bool operator() (deg_t i, deg_t j) const {
 					if (i.deg < j.deg) return true;
 					else if (i.deg == j.deg) {
@@ -200,16 +200,14 @@ namespace bitgraph {
 
 		}
 
-		struct weightMore :
-			public binary_function<wset_t, wset_t, bool> {
+		struct weightMore {
 			bool operator() (wset_t i, wset_t j) const {
 				if (i.wv > j.wv) return true;
 				return false;
 			}
 		};
 
-		struct weightLess :
-			public binary_function<wset_t, wset_t, bool> {
+		struct weightLess {
 			bool operator() (wset_t i, wset_t j) const {
 				if (i.wv < j.wv) return true;
 				return false;
@@ -259,8 +257,7 @@ namespace bitgraph {
 			lv[i].degv = g.degree(i);
 		}
 
-		struct weightDegMore :
-			public binary_function<wset_t, wset_t, bool> {
+		struct weightDegMore {
 			bool operator() (wset_t i, wset_t j) const {
 				if (i.wv * i.degv > j.wv * j.degv) return true;
 				return false;
@@ -268,8 +265,7 @@ namespace bitgraph {
 		};
 
 
-		struct weightDegLess :
-			public binary_function<wset_t, wset_t, bool> {
+		struct weightDegLess {
 			bool operator() (wset_t i, wset_t j) const {
 				if (i.wv * i.degv < j.wv * j.degv) return true;
 				return false;

--- a/src/graph/algorithms/graph_sort.h
+++ b/src/graph/algorithms/graph_sort.h
@@ -985,14 +985,14 @@ namespace bitgraph {
 
 	template<>
 	inline
-		int GraphSort<ugraph>::reorder_in_place(const vint& new_order, ostream* o) {
+		int GraphSort<ugraph>::reorder_in_place(const vint&, ostream*) {
 		struct this_type_is_not_available_for_GraphSort {};
 		return 0;
 	}
 
 	template<>
 	inline
-		int GraphSort<ugraph>::reorder_in_place(const vint& new_order, Decode& d, ostream* o) {
+		int GraphSort<ugraph>::reorder_in_place(const vint&, Decode& d, ostream*) {
 		struct this_type_is_not_available_for_GraphSort {};
 		return 0;
 	}

--- a/src/graph/algorithms/kcore.h
+++ b/src/graph/algorithms/kcore.h
@@ -410,7 +410,7 @@ namespace bitgraph {
 		bin_sort(is_subg);
 
 		auto u = EMPTY_ELEM;
-		auto v = EMPTY_ELEM;
+		//auto v = EMPTY_ELEM;
 
 		if (!is_subg) {
 
@@ -1044,7 +1044,7 @@ namespace bitgraph {
 
 		auto max_size = 1;
 		auto iter = 1;
-		auto from = EMPTY_ELEM;
+		//auto from = EMPTY_ELEM;
 
 		vint curr_clique;
 		vint largest_clique;
@@ -1063,7 +1063,7 @@ namespace bitgraph {
 			bbneigh = g_.neighbors(ver_[i]);
 
 			//iterates over all vertices to pick them in degeneracy ordering
-			for (auto j = i - 1; j >= 0; --j) {
+			for (auto j = i - 1; j >= 0; --j) { // FIXME unsigned >= 0 always true
 
 				if (deg_[ver_[j]] < max_size) { break; }
 
@@ -1109,7 +1109,7 @@ namespace bitgraph {
 		struct less_kcore {
 			less_kcore(vector<int>& pos, vector<int>& ver, vector<int>& deg) :pos(pos), ver(ver), deg(deg) {}
 			bool operator()(int lhs, int rhs) const {
-				return(deg[ver[pos[lhs]]] > deg[ver[pos[lhs]]]);
+				return(deg[ver[pos[lhs]]] > deg[ver[pos[lhs]]]); // FIXME should it be rhs?
 			}
 			vector<int>& pos;
 			vector<int>& ver;
@@ -1138,7 +1138,7 @@ namespace bitgraph {
 
 		auto max_size = 1;
 		auto iter = 1;
-		auto from = EMPTY_ELEM;
+		//auto from = EMPTY_ELEM;
 
 		vint curr_clique;
 		vint largest_clique;

--- a/src/graph/examples/gen_random_bench.cpp
+++ b/src/graph/examples/gen_random_bench.cpp
@@ -61,7 +61,7 @@ public:
 			parse(argv);
 		}
 		catch (const GraphParseError& e) {
-			LOG_ERROR(e.what());
+			LOG_ERROR("%s", e.what());
 			LOG_ERROR("exiting...");
 			std::exit(-1);
 		}		

--- a/src/graph/formats/mmio.cpp
+++ b/src/graph/formats/mmio.cpp
@@ -262,7 +262,7 @@ namespace bitgraph {
     /* use when I[], J[], and val[]J, and val[] are already allocated */
     /******************************************************************/
 
-    int mm_read_mtx_crd_data(FILE* f, int M, int N, int nz, int I[], int J[],
+    int mm_read_mtx_crd_data(FILE* f, int /*M*/, int /*N*/, int nz, int I[], int J[],
         double val[], MM_typecode matcode)
     {
         int i;
@@ -459,12 +459,16 @@ namespace bitgraph {
         char* mm_strdup(const char*);
         int error = 0;
 
+        /* prevent uninitialized variable warning */
+        for (int i=0; i<4; ++i)
+            types[i] = 0;
+
         /* check for MTX type */
         if (mm_is_matrix(matcode))
             //types[0] = MM_MTX_STR;
             strcpy(types[0], MM_MTX_STR);
         else
-            error = 1;
+            error = 1; // FIXME unused
 
         /* check for CRD or ARR matrix */
         if (mm_is_sparse(matcode))

--- a/src/graph/simple_graph.cpp
+++ b/src/graph/simple_graph.cpp
@@ -135,7 +135,7 @@ int Graph<BitSet_t>::reset	(std::size_t NV, string name) {
 	}
 	catch (const std::bad_alloc& e) {
 		LOG_ERROR("memory for graph not allocated - Graph<BitSet_t>::reset");
-		LOG_ERROR(e.what());
+		LOG_ERROR("%s", e.what());
 		NV_ = 0;
 		NBB_ = 0;
 		return -1;

--- a/src/graph/simple_graph.h
+++ b/src/graph/simple_graph.h
@@ -614,7 +614,7 @@ namespace bitgraph {
 		}
 		catch (const std::bad_alloc& e) {
 			LOG_ERROR("memory for graph not allocated - Graph<BitSetT>::reset");
-			LOG_ERROR(e.what());
+			LOG_ERROR("%s", e.what());
 			NV_ = 0;
 			NBB_ = 0;
 			return -1;

--- a/src/graph/simple_graph.h
+++ b/src/graph/simple_graph.h
@@ -518,7 +518,7 @@ namespace bitgraph {
 	template<class BitSetT>
 	inline
 		Graph<BitSetT>::Graph(string filename) :
-		NV_(0), NBB_(0), NE_(0),
+		NV_(0), NE_(0), NBB_(0),
 		name_(""), path_("")
 	{
 		if (reset(filename) == -1) {

--- a/src/graph/tests/test_sparse_graph.cpp
+++ b/src/graph/tests/test_sparse_graph.cpp
@@ -13,7 +13,7 @@
 #include "graph/algorithms/graph_gen.h"
 #include "gtest/gtest.h"
 #include <iostream>
-#include <strstream>
+#include <sstream>
 
 using namespace std;
 using namespace bitgraph;

--- a/src/graph/tests/test_ugraph.cpp
+++ b/src/graph/tests/test_ugraph.cpp
@@ -511,7 +511,7 @@ TEST(Ugraph, DISABLED_add_vertex_multiple) {
 #ifdef TEST_GRAPH_STEP_BY_STEP
 	LOG_ERROR("press any key to continue");
 	cin.get();
-#endif;
+#endif
 }
 
 TEST(Ugraph, DISABLED_add_single_vertex) {
@@ -566,7 +566,7 @@ TEST(Ugraph, DISABLED_add_single_vertex) {
 #ifdef TEST_GRAPH_STEP_BY_STEP
 	LOG_ERROR("press any key to continue");
 	cin.get();
-#endif;
+#endif
 }
 
 //////////////////

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -30,6 +30,7 @@
 #include <cstdio>
 #include <ctime>
 #include <initializer_list>
+#include <cstdarg>
 
 namespace bitgraph{
 
@@ -47,11 +48,11 @@ namespace bitgraph{
 //////////////////////////////////////////
 //legacy logger macros compatibility
 
-#define LOG_ERROR(msg)			Error(msg)
-#define LOG_WARNING(msg)		Warning(msg)
-#define LOG_INFO(msg)			Info(msg)
-#define LOG_PRINT(msg)			Info(msg)
-#define LOG_DEBUG(msg)			Debug(msg)
+#define LOG_ERROR(...)			Error(__VA_ARGS__)
+#define LOG_WARNING(...)		Warning(__VA_ARGS__)
+#define LOG_INFO(...)			Info(__VA_ARGS__)
+#define LOG_PRINT(...)			Info(__VA_ARGS__)
+#define LOG_DEBUG(...)			Debug(__VA_ARGS__)
 
 //////////////////////
 #define LOG_PAK()				Info("press any key to continue")
@@ -102,34 +103,46 @@ static inline void logy_helper(const F& first, R&&... rest) {
 }
 
 // Direct logging functions with printf-style format strings
-template<typename... T>
-void _Debug(const char* format, T... args) {
+inline void __attribute__ ((format (printf, 1, 2)))
+_Debug(const char* format, ...) {
 	logy_header(" DEBUG: ");
-	std::fprintf(stderr, format, args...);
+	va_list ap;
+	va_start(ap, format);
+	std::fprintf(stderr, format, ap);
+	va_end(ap);
 	std::fprintf(stderr, "\n");
 	std::fflush(stderr);
 }
 
-template<typename... T>
-void _Info(const char* format, T... args) {
+inline void __attribute__ ((format (printf, 1, 2)))
+_Info(const char* format, ...) {
 	logy_header(" INFO: ");
-	std::fprintf(stderr, format, args...);
+	va_list ap;
+	va_start(ap, format);
+	std::fprintf(stderr, format, ap);
+	va_end(ap);
 	std::fprintf(stderr, "\n");
 	std::fflush(stderr);
 }
 
-template<typename... T>
-void _Warning(const char* format, T... args) {
+inline void __attribute__ ((format (printf, 1, 2)))
+_Warning(const char* format, ...) {
 	logy_header(" WARNING: ");
-	std::fprintf(stderr, format, args...);
+	va_list ap;
+	va_start(ap, format);
+	std::fprintf(stderr, format, ap);
+	va_end(ap);
 	std::fprintf(stderr, "\n");
 	std::fflush(stderr);
 }
 
-template<typename... T>
-void _Error(const char* format, T... args) {
+inline void __attribute__ ((format (printf, 1, 2)))
+_Error(const char* format, ...) {
 	logy_header(" ERROR: ");
-	std::fprintf(stderr, format, args...);
+	va_list ap;
+	va_start(ap, format);
+	std::vfprintf(stderr, format, ap);
+	va_end(ap);
 	std::fprintf(stderr, "\n");
 	std::fflush(stderr);
 }


### PR DESCRIPTION
* Used va_list rather than variadic template for logging functions, since gcc is then able to check for format errors.
* Enabled -Wall -Wextra
* Fixed some small things found by the complier.  There are still a lot of warnings.  I put "FIXME" on lines that seemed buggy where I wasn't sure of the fix.